### PR TITLE
Fix missing return for Loon app DTO

### DIFF
--- a/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
+++ b/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
@@ -352,6 +352,7 @@ class AppAPI(MethodView):
         dto.deeplink = f'loon://import?nodelist={self.user_panel_encoded_url}'
         ins_url = 'https://apps.apple.com/app/id1373567447'
         dto.install = [self.__get_app_install_dto(AppInstallType.app_store, ins_url)]
+        return dto
 
     def __get_stash_app_dto(self):
         dto = AppSchema()


### PR DESCRIPTION
## Summary
- ensure the Loon client helper mirrors the other DTO helpers by returning its schema instance so it shows up in serialized responses

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d860b93b608331bdfd33c6314c66f1